### PR TITLE
Workaround for invalid main definition

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,11 @@ export default async function (userOptions: IOptions): Promise<void> {
         // Skip if no main
         if (!pkg.main) continue;
 
+        // Workaround for invalid main definition.
+        if (Array.isArray(pkg.main)) {
+           pkg.main = pkg.main[0];
+        }
+
         // Set entry file (browser field not used due to being non-standard and otherwise complex)
         depOptions.browserifyOptions.entries = joinPathSegments(options.inputDir, depName, pkg.main ||  "./");
 


### PR DESCRIPTION
Some old packages, uses main as array. (Ex bootstrap-treeview). This workaround changes pkg.main on the fly for convert it in simple string.